### PR TITLE
feat(data): SQLite persistence layer (encrypted + migrations)

### DIFF
--- a/Sources/SSHAIClient/Core/Data/KeychainStore.swift
+++ b/Sources/SSHAIClient/Core/Data/KeychainStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Security
+import CryptoKit
+
+enum KeychainStore {
+    private static let account = "com.sshaiclient.datakey.v1"
+
+    static func getOrCreateKey() throws -> SymmetricKey {
+        if let existing = try? loadKeyData() {
+            return SymmetricKey(data: existing)
+        }
+        // Generate random 32-byte key
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else { throw NSError(domain: "KeychainStore", code: Int(status)) }
+        let data = Data(bytes)
+        try saveKeyData(data)
+        return SymmetricKey(data: data)
+    }
+
+    private static func loadKeyData() throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: kCFBooleanTrue as Any,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = item as? Data else {
+            throw NSError(domain: "KeychainStore", code: Int(status))
+        }
+        return data
+    }
+
+    private static func saveKeyData(_ data: Data) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            // Update existing
+            let updateQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: account
+            ]
+            let attrs: [String: Any] = [kSecValueData as String: data]
+            let s = SecItemUpdate(updateQuery as CFDictionary, attrs as CFDictionary)
+            guard s == errSecSuccess else { throw NSError(domain: "KeychainStore", code: Int(s)) }
+        } else if status != errSecSuccess {
+            throw NSError(domain: "KeychainStore", code: Int(status))
+        }
+    }
+}

--- a/Sources/SSHAIClient/Core/Data/KeychainStore.swift
+++ b/Sources/SSHAIClient/Core/Data/KeychainStore.swift
@@ -6,7 +6,7 @@ enum KeychainStore {
     private static let account = "com.sshaiclient.datakey.v1"
 
     static func getOrCreateKey() throws -> SymmetricKey {
-        if let existing = try? loadKeyData() {
+        if let existing = try loadKeyData() {
             return SymmetricKey(data: existing)
         }
         // Generate random 32-byte key

--- a/Sources/SSHAIClient/Core/Data/LocalDataManager.swift
+++ b/Sources/SSHAIClient/Core/Data/LocalDataManager.swift
@@ -100,7 +100,9 @@ public final class LocalDataManager: @unchecked Sendable {
 
     private func decryptFromB64(_ b64: String) throws -> String {
         let key = try SecureStore.getKey()
-        let combined = Data(base64Encoded: b64) ?? Data()
+        guard let combined = Data(base64Encoded: b64) else { 
+            throw NSError(domain: "LocalDataManager", code: -3, userInfo: [NSLocalizedDescriptionKey: "Invalid base64 string for decryption"])
+        }
         let box = try AES.GCM.SealedBox(combined: combined)
         let data = try AES.GCM.open(box, using: key)
         return String(decoding: data, as: UTF8.self)

--- a/Sources/SSHAIClient/Core/Data/LocalDataManager.swift
+++ b/Sources/SSHAIClient/Core/Data/LocalDataManager.swift
@@ -1,4 +1,47 @@
 import Foundation
+import SQLite
+import CryptoKit
+
+// Avoid Expression name collision with Swift 6
+private typealias Expression = SQLite.Expression
+
+// MARK: - Public Data Models
+public struct SSHConnection: Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let host: String
+    public let port: Int
+    public let username: String
+    public let createdAt: Date
+}
+
+public struct CommandRecord: Equatable, Identifiable {
+    public let id: String
+    public let sessionId: String
+    public let command: String
+    public let stdout: String?
+    public let stderr: String?
+    public let exitCode: Int
+    public let executedAt: Date
+    public let workingDirectory: String?
+    public let isAiGenerated: Bool
+}
+
+public struct Script: Equatable, Identifiable {
+    public let id: String
+    public let title: String
+    public let language: String // shell|python|ts
+    public let content: String
+    public let createdAt: Date
+    public let updatedAt: Date
+}
+
+public struct AiCacheEntry: Equatable, Identifiable {
+    public let id: String
+    public let inputHash: String
+    public let payload: Data
+    public let createdAt: Date
+}
 
 /// LocalDataManager encapsulates SQLite-backed persistence for the app.
 /// It creates and migrates tables, and provides typed CRUD operations for:
@@ -11,96 +54,226 @@ import Foundation
 /// - This is a stub defining contracts and data models, without DB implementation.
 /// - Real implementation should use SQLite.swift with proper error handling and migrations.
 public final class LocalDataManager: @unchecked Sendable {
+    
+    private var db: SQLite.Connection?
+
+    // MARK: - Table Definitions
+    private let connections = Table("connections")
+    private let commandHistory = Table("command_history")
+    private let scripts = Table("scripts")
+    private let aiSuggestions = Table("ai_suggestions")
+
+    // MARK: - Column Definitions
+    private let id = Expression<String>("id")
+    private let name = Expression<String>("name")
+    private let host = Expression<String>("host")
+    private let port = Expression<Int>("port")
+    private let username = Expression<String>("username")
+    private let createdAt = Expression<Date>("createdAt")
+    
+    private let sessionId = Expression<String>("sessionId")
+    private let command = Expression<String>("command")
+    private let stdout = Expression<String?>("stdout")
+    private let stderr = Expression<String?>("stderr")
+    private let exitCode = Expression<Int>("exitCode")
+    private let executedAt = Expression<Date>("executedAt")
+    private let workingDirectory = Expression<String?>("workingDirectory")
+    private let isAiGenerated = Expression<Bool>("isAiGenerated")
+    
+    private let title = Expression<String>("title")
+    private let language = Expression<String>("language")
+    private let content = Expression<String>("content")
+    private let updatedAt = Expression<Date>("updatedAt")
+
+    private let query = Expression<String>("query")
+    private let suggestion = Expression<String>("suggestion")
+    private let confidence = Expression<Double>("confidence")
+    private let accepted = Expression<Bool>("accepted")
+    
+    // MARK: - Crypto helpers
+    private func encryptToB64(_ plaintext: String) throws -> String {
+        let key = try SecureStore.getKey()
+        let sealed = try AES.GCM.seal(Data(plaintext.utf8), using: key)
+        guard let combined = sealed.combined else { throw NSError(domain: "LocalDataManager", code: -2) }
+        return combined.base64EncodedString()
+    }
+
+    private func decryptFromB64(_ b64: String) throws -> String {
+        let key = try SecureStore.getKey()
+        let combined = Data(base64Encoded: b64) ?? Data()
+        let box = try AES.GCM.SealedBox(combined: combined)
+        let data = try AES.GCM.open(box, using: key)
+        return String(decoding: data, as: UTF8.self)
+    }
 	
 	public init() {}
-	// MARK: - Data Models
-	struct Connection: Equatable, Identifiable {
-		let id: String
-		let name: String
-		let host: String
-		let port: Int
-		let username: String
-		let createdAt: Date
-	}
-	
-	struct CommandRecord: Equatable, Identifiable {
-		let id: String
-		let sessionId: String
-		let command: String
-		let stdout: String?
-		let stderr: String?
-		let exitCode: Int32
-		let executedAt: Date
-		let workingDirectory: String?
-		let isAiGenerated: Bool
-	}
-	
-	struct Script: Equatable, Identifiable {
-		let id: String
-		let title: String
-		let language: String // shell|python|ts
-		let content: String
-		let createdAt: Date
-		let updatedAt: Date
-	}
-	
-	struct AiCacheEntry: Equatable, Identifiable {
-		let id: String
-		let inputHash: String
-		let payload: Data
-		let createdAt: Date
-	}
 	
 	// MARK: - Lifecycle
 	/// Initialize (open) the database, create tables if not exists, and run migrations.
 	/// - Throws: Underlying DB errors when initialization/migration fails.
-	func initialize() throws {
-		// Logic (not implemented):
-		// 1. Resolve DB file path in Documents.
-		// 2. Open connection with SQLite.swift.
-		// 3. Create tables if not exists.
-		// 4. Run pending migrations.
-		// 5. Seed built-in scripts (idempotent).
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func initialize() throws {
+        let fileManager = FileManager.default
+        let appSupportURL = try fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let dbDir = appSupportURL.appendingPathComponent("SSHAIClient")
+        try fileManager.createDirectory(at: dbDir, withIntermediateDirectories: true, attributes: nil)
+        let dbURL = dbDir.appendingPathComponent("sshaiclient.sqlite3")
+        
+        db = try SQLite.Connection(dbURL.path)
+        
+        try db?.transaction {
+            try MigrationManager.migrate(db: db!)
+            try createTables()
+        }
 	}
+
+    public func initializeForTesting() throws {
+        db = try SQLite.Connection(.inMemory)
+        try db?.transaction {
+            try MigrationManager.migrate(db: db!)
+            try createTables()
+        }
+    }
+    
+    private func createTables() throws {
+        try db?.run(connections.create(ifNotExists: true) { t in
+            t.column(id, primaryKey: true)
+            t.column(name)
+            t.column(host)
+            t.column(port)
+            t.column(username)
+            t.column(createdAt)
+        })
+        
+        try db?.run(commandHistory.create(ifNotExists: true) { t in
+            t.column(id, primaryKey: true)
+            t.column(sessionId)
+            t.column(command)
+            t.column(stdout)
+            t.column(stderr)
+            t.column(exitCode)
+            t.column(executedAt)
+            t.column(workingDirectory)
+            t.column(isAiGenerated)
+        })
+        
+        try db?.run(scripts.create(ifNotExists: true) { t in
+            t.column(id, primaryKey: true)
+            t.column(title)
+            t.column(language)
+            t.column(content)
+            t.column(createdAt)
+            t.column(updatedAt)
+        })
+        
+        try db?.run(aiSuggestions.create(ifNotExists: true) { t in
+            t.column(id, primaryKey: true)
+            t.column(query)
+            t.column(suggestion)
+            t.column(confidence)
+            t.column(accepted)
+        })
+    }
 	
 	// MARK: - CRUD: Connections
-	func upsertConnection(_ connection: Connection) throws {
-		// Insert or update connection by id.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func upsertConnection(_ connection: SSHConnection) throws {
+        let encHost = try encryptToB64(connection.host)
+        let encUser = try encryptToB64(connection.username)
+        try db?.run(connections.insert(or: .replace,
+            id <- connection.id,
+            name <- connection.name,
+            host <- encHost,
+            port <- connection.port,
+            username <- encUser,
+            createdAt <- connection.createdAt
+        ))
 	}
 	
-	func listConnections() throws -> [Connection] {
-		// Return all connections ordered by createdAt desc.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func listConnections() throws -> [SSHConnection] {
+        let query = connections.order(createdAt.desc)
+        return try db?.prepare(query).map { row in
+            let hostB64 = try row.get(host)
+            let userB64 = try row.get(username)
+            return SSHConnection(
+                id: try row.get(id),
+                name: try row.get(name),
+                host: try decryptFromB64(hostB64),
+                port: try row.get(port),
+                username: try decryptFromB64(userB64),
+                createdAt: try row.get(createdAt)
+            )
+        } ?? []
 	}
 	
-	func deleteConnection(id: String) throws {
-		// Delete by id, cascade cleanup if needed.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func deleteConnection(id: String) throws {
+        let q = connections.filter(self.id == id)
+        try db?.run(q.delete())
 	}
 	
 	// MARK: - CRUD: Command History
-	func appendCommand(_ record: CommandRecord) throws {
-		// Append command execution record.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func appendCommand(_ record: CommandRecord) throws {
+        try db?.run(commandHistory.insert(
+            id <- record.id,
+            sessionId <- record.sessionId,
+            command <- record.command,
+            stdout <- record.stdout,
+            stderr <- record.stderr,
+            exitCode <- record.exitCode,
+            executedAt <- record.executedAt,
+            workingDirectory <- record.workingDirectory,
+            isAiGenerated <- record.isAiGenerated
+        ))
 	}
 	
-	func listCommands(sessionId: String) throws -> [CommandRecord] {
-		// Return all commands in a session, ordered by executedAt asc.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func listCommands(sessionId: String) throws -> [CommandRecord] {
+        let q = commandHistory.filter(self.sessionId == sessionId).order(executedAt.asc)
+        return try db?.prepare(q).map { row in
+            CommandRecord(
+                id: try row.get(id),
+                sessionId: try row.get(self.sessionId),
+                command: try row.get(command),
+                stdout: try row.get(stdout),
+                stderr: try row.get(stderr),
+                exitCode: try row.get(exitCode),
+                executedAt: try row.get(executedAt),
+                workingDirectory: try row.get(workingDirectory),
+                isAiGenerated: try row.get(isAiGenerated)
+            )
+        } ?? []
 	}
 	
 	// MARK: - CRUD: Scripts
-	func upsertScript(_ script: Script) throws {
-		// Insert or update a script document.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func upsertScript(_ script: Script) throws {
+        try db?.run(scripts.insert(or: .replace,
+            id <- script.id,
+            title <- script.title,
+            language <- script.language,
+            content <- script.content,
+            createdAt <- script.createdAt,
+            updatedAt <- script.updatedAt
+        ))
 	}
 	
-	func listScripts(language: String?) throws -> [Script] {
-		// Optionally filter by language.
-		throw NSError(domain: "LocalDataManager", code: -1)
+	public func listScripts(language: String?) throws -> [Script] {
+        var q = scripts.order(updatedAt.desc)
+        if let lang = language {
+            q = q.filter(self.language == lang)
+        }
+        return try db?.prepare(q).map { row in
+            Script(
+                id: try row.get(id),
+                title: try row.get(title),
+                language: try row.get(self.language),
+                content: try row.get(content),
+                createdAt: try row.get(createdAt),
+                updatedAt: try row.get(updatedAt)
+            )
+        } ?? []
 	}
+
+    public func deleteScript(id scriptId: String) throws {
+        let q = scripts.filter(id == scriptId)
+        try db?.run(q.delete())
+    }
 	
 	// MARK: - AI Cache
 	func putCache(_ entry: AiCacheEntry) throws {
@@ -113,3 +286,4 @@ public final class LocalDataManager: @unchecked Sendable {
 		throw NSError(domain: "LocalDataManager", code: -1)
 	}
 }
+

--- a/Sources/SSHAIClient/Core/Data/MigrationManager.swift
+++ b/Sources/SSHAIClient/Core/Data/MigrationManager.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SQLite
+
+// Avoid Expression name collision
+private typealias Expression = SQLite.Expression
+
+enum MigrationManager {
+    /// Ensures meta table exists and schema_version is set.
+    /// For now, bootstrap to version 1 if missing.
+    static func migrate(db: SQLite.Connection) throws {
+        let meta = Table("meta")
+        let k = Expression<String>("key")
+        let v = Expression<String>("value")
+
+        try db.run(meta.create(ifNotExists: true) { t in
+            t.column(k, primaryKey: true)
+            t.column(v)
+        })
+
+        let versionRow = try db.pluck(meta.filter(k == "schema_version"))
+        if versionRow == nil {
+            try db.run(meta.insert(or: .replace, k <- "schema_version", v <- "1"))
+        }
+        // Future migrations: read version and apply incremental SQL changes, then update value.
+    }
+}

--- a/Sources/SSHAIClient/Core/Data/SecureStore.swift
+++ b/Sources/SSHAIClient/Core/Data/SecureStore.swift
@@ -1,0 +1,9 @@
+import Foundation
+import CryptoKit
+
+struct SecureStore {
+    static func getKey() throws -> SymmetricKey {
+        // Use Keychain-backed symmetric key
+        return try KeychainStore.getOrCreateKey()
+    }
+}

--- a/Tests/SSHAIClientTests/SSHAIClientPersistenceTests.swift
+++ b/Tests/SSHAIClientTests/SSHAIClientPersistenceTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SSHAIClient
+
+class SSHAIClientPersistenceTests: XCTestCase {
+
+    var dataManager: LocalDataManager!
+
+    override func setUpWithError() throws {
+        dataManager = LocalDataManager()
+        try dataManager.initializeForTesting()
+    }
+
+    override func tearDownWithError() throws {
+        dataManager = nil
+    }
+
+    func testConnectionCRUD_withEncryption() throws {
+        let connection = SSHConnection(id: "1", name: "test-encrypted", host: "localhost.encrypted", port: 2222, username: "testuser-encrypted", createdAt: Date())
+        try dataManager.upsertConnection(connection)
+
+        let connections = try dataManager.listConnections()
+        XCTAssertEqual(connections.count, 1)
+        let fetchedConnection = connections.first!
+        
+        XCTAssertEqual(fetchedConnection.name, "test-encrypted")
+        XCTAssertEqual(fetchedConnection.host, "localhost.encrypted")
+        XCTAssertEqual(fetchedConnection.username, "testuser-encrypted")
+
+        try dataManager.deleteConnection(id: "1")
+        let connectionsAfterDelete = try dataManager.listConnections()
+        XCTAssertEqual(connectionsAfterDelete.count, 0)
+    }
+    
+    func testCommandHistoryCRUD() throws {
+        let command = CommandRecord(id: "cmd1", sessionId: "session1", command: "ls -la", stdout: "total 0", stderr: nil, exitCode: 0, executedAt: Date(), workingDirectory: "/tmp", isAiGenerated: false)
+        try dataManager.appendCommand(command)
+        
+        let commands = try dataManager.listCommands(sessionId: "session1")
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands.first?.command, "ls -la")
+    }
+
+    func testScriptsCRUD() throws {
+        let now = Date()
+        let s = Script(id: "s1", title: "List Files", language: "shell", content: "ls -la", createdAt: now, updatedAt: now)
+        try dataManager.upsertScript(s)
+
+        var scripts = try dataManager.listScripts(language: nil)
+        XCTAssertEqual(scripts.count, 1)
+        XCTAssertEqual(scripts.first?.title, "List Files")
+
+        scripts = try dataManager.listScripts(language: "shell")
+        XCTAssertEqual(scripts.count, 1)
+
+        try dataManager.deleteScript(id: "s1")
+        scripts = try dataManager.listScripts(language: nil)
+        XCTAssertEqual(scripts.count, 0)
+    }
+}


### PR DESCRIPTION
Implements Track C data layer with SQLite.swift\n- Connections CRUD with AES-GCM encrypted host/username (Keychain-backed key)\n- Command history CRUD\n- Scripts CRUD (upsert/list/delete)\n- MigrationManager with schema_version=1\n- Unit tests for CRUD and encryption\n\nAI suggestions cache intentionally deferred until AI response schema is finalized.